### PR TITLE
DM-29599: CONFIG_SCHEMA: flatten the schema

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,8 +6,22 @@
 Version History
 ###############
 
+v1.7.0
+------
+
+Changes:
+
+* Change the CSC configuration schema to allow configuring all algorithms at once.
+  This supports a planned change to how configuration files are read.
+
+Requirements:
+
+* ts_salobj 6.3
+* ts_idl 2
+* IDL files for ATDome, ATDomeTrajectory and ATMCS built from ts_xml 8.1
+
 v1.6.0
-======
+------
 
 Changes:
 
@@ -31,7 +45,7 @@ Requirements:
 * IDL files for ATDome, ATDomeTrajectory and ATMCS built from ts_xml 8.1
 
 v1.5.1
-======
+------
 
 Changes:
 
@@ -46,7 +60,7 @@ Requirements:
 
 
 v1.5.0
-======
+------
 
 Changes:
 
@@ -61,7 +75,7 @@ Requirements:
 * IDL files for ATDome, ATDomeTrajectory and ATMCS built from ts_xml 4.1
 
 v1.4.7
-======
+------
 
 Changes:
 
@@ -74,7 +88,7 @@ Requirements:
 * IDL files for ATDome, ATDomeTrajectory and ATMCS built from ts_xml 4.1
 
 v1.4.6
-======
+------
 
 Changes:
 
@@ -87,7 +101,7 @@ Requirements:
 * IDL files for ATDome, ATDomeTrajectory and ATMCS built from ts_xml 4.1
 
 v1.4.5
-======
+------
 
 Changes:
 
@@ -101,7 +115,7 @@ Requirements:
 * IDL files for ATDome, ATDomeTrajectory and ATMCS built from ts_xml 4.1
 
 v1.4.4
-======
+------
 
 Changes:
 
@@ -115,7 +129,7 @@ Requirements:
 * IDL files for ATDome, ATDomeTrajectory and ATMCS built from ts_xml 4.1
 
 v1.4.3
-======
+------
 
 Changes:
 
@@ -128,7 +142,7 @@ Requirements:
 * IDL files for ATDome, ATDomeTrajectory and ATMCS built from ts_xml 4.1
 
 v1.4.2
-======
+------
 
 Changes:
 
@@ -144,7 +158,7 @@ Requirements:
 * IDL files for ATDome, ATDomeTrajectory and ATMCS built from ts_xml 4.1
 
 v1.4.1
-======
+------
 
 Changes:
 
@@ -157,7 +171,7 @@ Requirements:
 * IDL files for ATDome, ATDomeTrajectory and ATMCS built from ts_xml 4.1
 
 v1.4.0
-======
+------
 
 Changes:
 
@@ -171,7 +185,7 @@ Requirements:
 * IDL files for ATDome, ATDomeTrajectory and ATMCS built from ts_xml 4.1
 
 v1.3.4
-======
+------
 
 Changes:
 
@@ -184,7 +198,7 @@ Requirements:
 * IDL files for ATDome, ATDomeTrajectory and ATMCS built from ts_xml 4.1
 
 v1.3.3
-======
+------
 
 Changes:
 
@@ -195,7 +209,7 @@ Changes:
 * Update ``.travis.yml`` to remove ``sudo: false`` to github travis checks pass once again.
 
 v1.3.2
-======
+------
 
 Changes:
 
@@ -208,7 +222,7 @@ Requirements:
 * IDL files for ATDome, ATDomeTrajectory and ATMCS built from ts_xml 4.1
 
 v1.3.1
-======
+------
 
 Add conda build support.
 
@@ -220,7 +234,7 @@ Requirements:
 
 
 v1.3.0
-======
+------
 
 * Update CSC unit tests to use `lsst.ts.salobj.BaseCscTestCase`.
   Thus we now require ts_salobj 5.4.
@@ -234,7 +248,7 @@ Requirements:
 
 
 v1.2.0
-======
+------
 
 Update for ts_salobj 5.2: rename initial_simulation_mode to simulation_mode.
 
@@ -245,7 +259,7 @@ Requirements:
 * IDL files for ATDome, ATDomeTrajectory and ATMCS built from ts_xml 4.1
 
 v1.1.0
-======
+------
 Update for SAL 4.
 
 Other changes:
@@ -260,7 +274,7 @@ Requirements:
 * IDL files for ATDome, ATDomeTrajectory and ATMCS built from ts_xml 4.1
 
 v1.0.0
-======
+------
 Update for ATDome no longer having a SAL index.
 
 Requirements:
@@ -270,7 +284,7 @@ Requirements:
 * IDL files for ATDome, ATDomeTrajectory and ATMCS built from ts_xml 4.1
 
 v0.9.0
-======
+------
 In `algorithms.SimpleAlgorithm` scale daz by cos(el) so the dome is less likely to move unnecessarily.
 
 Other changes:
@@ -286,11 +300,11 @@ Requirements:
 * IDL files for ATDome, ATDomeTrajectory and ATMCS
 
 v0.8.1
-======
+------
 Add a dependency on ts_config_attcs to the ups table file.
 
 v0.8.0
-======
+------
 Use OpenSplice dds instead of SALPY libraries.
 
 Requirements:
@@ -304,7 +318,7 @@ Requirements:
   * ATMCS
 
 v0.7.0
-======
+------
 Make `ATDomeTrajectory.configure` async for ts_salobj 3.12.
 
 Requirements:
@@ -314,7 +328,7 @@ ts_sal 3.9
 ts_salobj 3.12
 
 v0.6.0
-======
+------
 Standardize configuration of `ATDomeTrajectory` by making it a subclass of `salobj.ConfigurableCsc`.
 
 Requirements:
@@ -324,7 +338,7 @@ Requirements:
 * ts_salobj v3.11
 
 v0.5.0
-======
+------
 Update for ts_ATDome v0.4.0.
 
 Requirements:

--- a/python/lsst/ts/ATDomeTrajectory/config_schema.py
+++ b/python/lsst/ts/ATDomeTrajectory/config_schema.py
@@ -37,31 +37,19 @@ properties:
     enum:
     - simple
     default: simple
-  algorithm_config:
+  simple:
+    description: Configuration for the "simple" algorithm.
     type: object
-allOf:
-# For each supported algorithm_name add a new if/then case below.
-# Warning: set the default values for each case at the algorithm_config level
-# (rather than deeper down on properties within algorithm_config),
-# so users can omit algorithm_config and still get proper defaults.
-- if:
     properties:
-      algorithm_name:
-        const: simple
-  then:
-    properties:
-      algorithm_config:
-        properties:
-          max_delta_azimuth:
-            type: number
-            description: ->
-              Maximum difference between dome and telescope azimuth before moving the dome (deg).
-              The default value is nearly where the dome vignettes the telescope.
-        required:
-        - max_delta_azimuth
-        default:
-          max_delta_azimuth: 5
-        additionalProperties: false
+      max_delta_azimuth:
+        type: number
+        description: ->
+          Maximum difference between dome and telescope azimuth before moving the dome (deg).
+          The default value is nearly where the dome vignettes the telescope.
+        default: 5
+    required:
+    - max_delta_azimuth
+    additionalProperties: false
 additionalProperties: false
 """
 )

--- a/python/lsst/ts/ATDomeTrajectory/dome_trajectory.py
+++ b/python/lsst/ts/ATDomeTrajectory/dome_trajectory.py
@@ -133,12 +133,14 @@ class ATDomeTrajectory(salobj.ConfigurableCsc):
         config : `types.SimpleNamespace`
             Configuration, as described by `CONFIG_SCHEMA`
         """
-        self.algorithm = AlgorithmRegistry[config.algorithm_name](
-            **config.algorithm_config
-        )
+        algorithm_name = config.algorithm_name
+        if algorithm_name not in AlgorithmRegistry:
+            raise salobj.ExpectedError(f"Unknown algorithm {algorithm_name}")
+        algorithm_config = getattr(config, config.algorithm_name)
+        self.algorithm = AlgorithmRegistry[config.algorithm_name](**algorithm_config)
         self.evt_algorithm.set_put(
             algorithmName=config.algorithm_name,
-            algorithmConfig=yaml.dump(config.algorithm_config),
+            algorithmConfig=yaml.dump(algorithm_config),
         )
 
     async def atmcs_target_callback(self, target):

--- a/tests/data/config/invalid_bad_max_daz.yaml
+++ b/tests/data/config/invalid_bad_max_daz.yaml
@@ -1,3 +1,3 @@
 algorithm_name: "simple"
-algorithm_config:
+simple:
   max_delta_azimuth: "invalid value"

--- a/tests/data/config/invalid_no_such_algorithm_config_name.yaml
+++ b/tests/data/config/invalid_no_such_algorithm_config_name.yaml
@@ -1,3 +1,5 @@
 algorithm_name: "simple"
 simple:
   max_delta_azimuth: 7.1
+not_an_algorithm:
+  arbitrary_parameter_name: 7.1

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -38,30 +38,24 @@ class ValidationTestCase(unittest.TestCase):
         default_max_daz = 5  # hard-coded in the schema
         result = self.validator.validate(None)
         self.assertEqual(result["algorithm_name"], "simple")
-        self.assertEqual(
-            result["algorithm_config"], dict(max_delta_azimuth=default_max_daz)
-        )
+        self.assertEqual(result["simple"], dict(max_delta_azimuth=default_max_daz))
 
     def test_name_specified(self):
         default_max_daz = 5  # hard-coded in the schema
         data = dict(algorithm_name="simple")
         result = self.validator.validate(data)
         self.assertEqual(result["algorithm_name"], "simple")
-        self.assertEqual(
-            result["algorithm_config"], dict(max_delta_azimuth=default_max_daz)
-        )
+        self.assertEqual(result["simple"], dict(max_delta_azimuth=default_max_daz))
 
     def test_all_specified(self):
         max_delta_azimuth = 3.5
         data = dict(
             algorithm_name="simple",
-            algorithm_config=dict(max_delta_azimuth=max_delta_azimuth),
+            simple=dict(max_delta_azimuth=max_delta_azimuth),
         )
         result = self.validator.validate(data)
         self.assertEqual(result["algorithm_name"], "simple")
-        self.assertEqual(
-            result["algorithm_config"], dict(max_delta_azimuth=max_delta_azimuth)
-        )
+        self.assertEqual(result["simple"], dict(max_delta_azimuth=max_delta_azimuth))
 
     def test_bad_algorithm_name(self):
         data = dict(algorithm_name="invalid_name")
@@ -70,7 +64,7 @@ class ValidationTestCase(unittest.TestCase):
 
     def test_bad_algorithm_config(self):
         """The current schema only checks for a dict."""
-        data = dict(algorithm_name="simple", algorithm_config=45)
+        data = dict(algorithm_name="simple", simple=45)
         with self.assertRaises(jsonschema.exceptions.ValidationError):
             self.validator.validate(data)
 


### PR DESCRIPTION
so that all values for all algorithms can be specified at the same time.
This is needed in order to support loading configuration data sequentially
from multiple files.